### PR TITLE
feat: Remove config scene

### DIFF
--- a/fightsticker/__init__.py
+++ b/fightsticker/__init__.py
@@ -86,6 +86,10 @@ IMAGES_LEVERLESS = {
     "rt": "buttonhb.png",
     "lt": "buttonhb.png",
 }
+# Window width
+WINDOW_WIDTH = 640
+# Window height
+WINDOW_HEIGHT = 390
 
 
 def read_config(filename):


### PR DESCRIPTION
Configuration of deadzones can happen in the GUI now. There's no need to be able to do it in pyglet.

Additionally, we abstract window width and height