### PR TITLE
fix: CLI immediate open behavior

### DIFF
--- a/fightsticker/window.py
+++ b/fightsticker/window.py
@@ -112,8 +112,10 @@ class Window(Gtk.ApplicationWindow):
         args = argv[1:]
         option = parser.parse_args(args)
         if option.TRADITIONAL:
+            self.close()
             run(layout="traditional", config=self.config)
         elif option.LEVERLESS:
+            self.close()
             run(layout="leverless", config=self.config)
 
     def on_prefs_clicked(self, action, param):


### PR DESCRIPTION
When opening using the `-t` or `-l` options, the window now closes just like when clicking the launch button