### PR TITLE
feat: Normalize dpad vector

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -4,7 +4,7 @@ APPNAME="Fightsticker"
 ID=me.zevlee.Fightsticker
 AUTHOR="Zev Lee"
 DESCRIPTION="Display fightstick inputs for streaming and testing purposes"
-VERSION=0.9.0
+VERSION=0.9.1
 LICENSE=LICENSE
 REQUIREMENTS=requirements.txt
 

--- a/fightsticker/__init__.py
+++ b/fightsticker/__init__.py
@@ -4,7 +4,7 @@ from os.path import dirname, join
 from platformdirs import user_config_dir
 
 # Version
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 # Application name
 APPNAME = "Fightsticker"
 # Application ID

--- a/fightsticker/fightstick.py
+++ b/fightsticker/fightstick.py
@@ -199,8 +199,8 @@ class TraditionalScene(LayoutScene):
         """
         assert _debug_print(f"Moved Dpad: {vector.x, vector.y}")
         center_x, center_y = self.layout["stick"]
-        center_x += vector.x * 50
-        center_y += vector.y * 50
+        center_x += vector.normalize().x * 50
+        center_y += vector.normalize().y * 50
         self.stick_spr.position = center_x, center_y, 0
 
 


### PR DESCRIPTION
We normalize the vector for dpad display in the traditional layout to ensure that the joystick doesn't appear to overextend on the diagonals. In doing so, the joystick appears to have a more circular gate rather than a square one.