### PR TITLE
feat: Cap joystick distance

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -4,7 +4,7 @@ APPNAME="Fightsticker"
 ID=me.zevlee.Fightsticker
 AUTHOR="Zev Lee"
 DESCRIPTION="Display fightstick inputs for streaming and testing purposes"
-VERSION=0.10.0
+VERSION=0.11.0
 LICENSE=LICENSE
 REQUIREMENTS=requirements.txt
 

--- a/fightsticker/__init__.py
+++ b/fightsticker/__init__.py
@@ -4,7 +4,7 @@ from os.path import dirname, join
 from platformdirs import user_config_dir
 
 # Version
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 # Application name
 APPNAME = "Fightsticker"
 # Application ID

--- a/fightsticker/fightstick.py
+++ b/fightsticker/fightstick.py
@@ -190,9 +190,15 @@ class TraditionalScene(LayoutScene):
         assert _debug_print(f"Moved Stick: {stick}, {vector.x, vector.y}")
         if stick == "leftstick":
             center_x, center_y = self.layout["stick"]
-            if vector.length() > self.manager.stick_deadzone:
+            if 1 > vector.length() > self.manager.stick_deadzone:
                 center_x += vector.x * 50
                 center_y += vector.y * 50
+            elif vector.length() > self.manager.stick_deadzone:
+                # Normalize the vector if its length exceeds 1.0,
+                # capping the distance from the center to a max of 50
+                # in all directions
+                center_x += vector.normalize().x * 50
+                center_y += vector.normalize().y * 50
             self.stick_spr.position = center_x, center_y, 0
 
     def on_dpad_motion(self, controller, vector):


### PR DESCRIPTION
Cap the jostick distance to 50 in the event that its magnitude exceeds 1. This prevents instances in which the joystick sprite could be drawn beyond its intended limit of 50