### PR TITLE
feat: Add images fallback

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -4,7 +4,7 @@ APPNAME="Fightsticker"
 ID=me.zevlee.Fightsticker
 AUTHOR="Zev Lee"
 DESCRIPTION="Display fightstick inputs for streaming and testing purposes"
-VERSION=0.12.0
+VERSION=0.12.1
 LICENSE=LICENSE
 REQUIREMENTS=requirements.txt
 

--- a/fightsticker/__init__.py
+++ b/fightsticker/__init__.py
@@ -4,7 +4,7 @@ from os.path import dirname, join
 from platformdirs import user_config_dir
 
 # Version
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 # Application name
 APPNAME = "Fightsticker"
 # Application ID

--- a/fightsticker/fightstick.py
+++ b/fightsticker/fightstick.py
@@ -26,6 +26,7 @@ _debug_print("Debugging Active")
 
 # Load the theme from the /theme folder.
 pyglet.resource.path.append(join(CONF, "images"))
+pyglet.resource.path.append(join(APPDIR, "images"))
 pyglet.resource.reindex()
 _debug_print("Theme Loaded")
 


### PR DESCRIPTION
Ensure that images can be found in the application directory in the event that the user configuration directory does not yet exist. The user config dir still obviously takes precedence.